### PR TITLE
Corrected timezone handling.

### DIFF
--- a/mod_test/models.py
+++ b/mod_test/models.py
@@ -172,7 +172,10 @@ class TestProgress(Base):
         tz = get_localzone()
         if timestamp is None:
             timestamp = tz.localize(datetime.datetime.now(), is_dst=None)
-        self.timestamp = timestamp.astimezone(pytz.UTC)
+            timestamp = timestamp.astimezone(pytz.UTC)
+        if timestamp.tzinfo is None:
+            timestamp = pytz.utc.localize(timestamp, is_dst=None)
+        self.timestamp = timestamp
         self.message = message
 
     def __repr__(self):


### PR DESCRIPTION
If the timezone if none it will 
1. Find and associate localtime zone to it.
2. Convert it to UTC.

But if timezone is not None , it checks if tzinfo is  None
1. Associate it with UTC timezone.