### PR TITLE
[FIX] forgot to add "not" in previous pr

### DIFF
--- a/mod_ci/controllers.py
+++ b/mod_ci/controllers.py
@@ -526,9 +526,9 @@ def progress_reporter(test_id, token):
                         pr = test.progress_data()
                         endtime = pr['end']
                         starttime = pr['start']
-                        if endtime.tzinfo is None:
+                        if endtime.tzinfo is not None:
                             endtime.replace(tzinfo=None)
-                        if starttime.tzinfo is None:
+                        if starttime.tzinfo is not None:
                             starttime.replace(tzinfo=None)
                         last_running_test = endtime - starttime
                         updated_average = (updated_average +


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/canihavesomecoffee/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

{pull request content here}
we have to set tzinfo = none where its not none. I just forgot to add not. :)