### PR TITLE
[FIX] Categories not toggling on some browsers.

### DIFF
--- a/templates/test/by_id.html
+++ b/templates/test/by_id.html
@@ -199,7 +199,7 @@
             
             $('.category-header').on('click', function(){
                 var id = $(this).data('category');
-                $('table[data-category="'+id+'"').toggleClass('hide');
+                $('table[data-category="'+id+'"]').toggleClass('hide');
             });
             $('#progress_button').on('click', function(){
                 var content = ($(this).val().indexOf('Show') === 0 ? 'Hide' : 'Show')+' test progress';


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/canihavesomecoffee/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

Apparently Chrome is smart enough to compensate missing bracket, but Safari is not. Added the missing bracket.

