### PR TITLE
[FIX] Predicted waiting time adapted to platform

### DIFF
--- a/mod_test/controllers.py
+++ b/mod_test/controllers.py
@@ -58,16 +58,13 @@ def get_data_for_test(test, title=None):
     hours = 0
     minutes = 0
     queued_tests = 0
-    ptest = g.db.query(TestProgress.test_id).filter(and_(
-        TestProgress.test_id == Test.id,
-        Test.platform == test.platform)).distinct().all()
     # evaluating estimated time if the test is still in queue
     if len(test.progress) == 0:
         var_average = 'average_time_' + test.platform.value
         queued_kvm = g.db.query(Kvm.test_id).filter(
             Kvm.test_id < test.id).subquery()
         queued_kvm_entries = g.db.query(Test.id).filter(and_(
-            Test.id.in_(queued_kvm),Test.platform == test.platform))
+            Test.id.in_(queued_kvm), Test.platform == test.platform))
         kvm_test = g.db.query(
             TestProgress.test_id,
             label('time', func.group_concat(TestProgress.timestamp))
@@ -84,7 +81,7 @@ def get_data_for_test(test, title=None):
             end = datetime.strptime(timestamps[-1], '%Y-%m-%d %H:%M:%S')
             time_run += (end - start).total_seconds()
         # subtracting current running tests
-        total = (average_duration * (queued_tests+1)) - time_run
+        total = (average_duration * (queued_tests + 1)) - time_run
         minutes = (total % 3600) // 60
         hours = total // 3600
 
@@ -146,8 +143,7 @@ def get_data_for_test(test, title=None):
         'title': title,
         'next': queued_tests,
         'min': minutes,
-        'hr': hours,
-        'ptest': ptest
+        'hr': hours
     }
 
 

--- a/mod_test/controllers.py
+++ b/mod_test/controllers.py
@@ -58,10 +58,16 @@ def get_data_for_test(test, title=None):
     hours = 0
     minutes = 0
     queued_tests = 0
+    ptest = g.db.query(TestProgress.test_id).filter(and_(
+        TestProgress.test_id == Test.id,
+        Test.platform == test.platform)).distinct().all()
     # evaluating estimated time if the test is still in queue
     if len(test.progress) == 0:
-        queued_kvm_entries = g.db.query(Kvm.test_id).filter(
+        var_average = 'average_time_' + test.platform.value
+        queued_kvm = g.db.query(Kvm.test_id).filter(
             Kvm.test_id < test.id).subquery()
+        queued_kvm_entries = g.db.query(Test.id).filter(and_(
+            Test.id.in_(queued_kvm),Test.platform == test.platform))
         kvm_test = g.db.query(
             TestProgress.test_id,
             label('time', func.group_concat(TestProgress.timestamp))
@@ -69,7 +75,7 @@ def get_data_for_test(test, title=None):
             TestProgress.test_id.in_(queued_kvm_entries)
         ).group_by(TestProgress.test_id).all()
         average_duration = float(GeneralData.query.filter(
-            GeneralData.key == 'average_time').first().value)
+            GeneralData.key == var_average).first().value)
         queued_tests = len(kvm_test)
         time_run = 0
         for pr_test in kvm_test:
@@ -78,7 +84,7 @@ def get_data_for_test(test, title=None):
             end = datetime.strptime(timestamps[-1], '%Y-%m-%d %H:%M:%S')
             time_run += (end - start).total_seconds()
         # subtracting current running tests
-        total = (average_duration * queued_tests) - time_run
+        total = (average_duration * (queued_tests+1)) - time_run
         minutes = (total % 3600) // 60
         hours = total // 3600
 
@@ -140,7 +146,8 @@ def get_data_for_test(test, title=None):
         'title': title,
         'next': queued_tests,
         'min': minutes,
-        'hr': hours
+        'hr': hours,
+        'ptest': ptest
     }
 
 


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/canihavesomecoffee/sample-platform/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

{pull request content here}
In mod_ci, it is check the platform according to that, 2 keys have been added, one controlling time for one platform and one key for another, if more platforms will be added, it will be handled automatically by adding key 'average_time_{platform}'.
In mod_home, only tests in kvm have been considered whose platform match with the test handled by the user.